### PR TITLE
Test/code cov config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,34 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+        target: 50
+        threshold: 10
+
+      binary:
+        informational: true
+        target: 50
+        threshold: 10
+        paths:
+          - bin
+
+      library:
+        informational: true
+        target: 50
+        threshold: 10
+        paths:
+          - lib
+
+      wasm:
+        informational: true
+        target: 50
+        threshold: 10
+        paths:
+          - wasm
+
+    patch:
+      default:
+        informational: true
+        target: 50
+        threshold: 10

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,11 +1,6 @@
 coverage:
   status:
     project:
-      default:
-        informational: true
-        target: 50
-        threshold: 10
-
       binary:
         informational: true
         target: 50
@@ -14,14 +9,14 @@ coverage:
           - bin
 
       library:
-        informational: true
+        informational: false
         target: 50
         threshold: 10
         paths:
           - lib
 
       wasm:
-        informational: true
+        informational: false
         target: 50
         threshold: 10
         paths:


### PR DESCRIPTION
This PR will make code coverage comments more valuable by making it clear that it will not fail commits in PRs for the binary target or meta files, and reduces the required coverage to 50%