### PR TITLE
fix(cli): remove unneeded flag

### DIFF
--- a/bin/src/cli.rs
+++ b/bin/src/cli.rs
@@ -17,9 +17,6 @@ pub(super) struct Arguments {
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub(super) quiet: u8,
 
-    #[arg(short, long, default_value = ".")]
-    pub(super) output: PathBuf,
-
     #[command(subcommand)]
     pub(super) sub_command: Commands,
 }


### PR DESCRIPTION
Removes the deprecated global flag for outputs because it has been superseded by `build --observatory-output -universe-output`, and `simulate -output`.