### PR TITLE
chore(svg output): remove todo comment that was previously resolved

### DIFF
--- a/lib/src/output/svg.rs
+++ b/lib/src/output/svg.rs
@@ -114,7 +114,6 @@ pub fn new_document<P: Projection>(
             )
             .set("cx", projected_location.x)
             .set("cy", projected_location.y)
-            // TODO: set color based on body type or name? (Will likely require user defined settings)
             .set("fill", "#FFF")
             .set(
                 "class",


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - 📖 Read the Contributing Guide: https://github.com/2sugarcubes/astrograph/blob/dev/.github/CONTRIBUTING.md#i-want-to-contribute
    - 📖 Read the Code of Conduct: https://github.com/2sugarcubes/astrograph/blob/dev/CODE_OF_CONDUCT.md
    - 👷‍♀️ Create small PRs. The majority of PRs should only need to modify one or two files.
    - ✅ Provide tests for your changes.
    - 📝 Use descriptive commit messages.
    - 📗 Update any related documentation and include any relevant screenshots.

-->

## Description

Removes unnecessary to-do comment that was previously resolved in #21.

<!--
TODO: e.g. This changes the log statement in `FILE.rs` to be more human
  readable.
If it doesn't resolve an issue please also provide a description as to
  why it is beneficial to most users or developers.
  e.g. This PR increases test coverage, catching potential future regressions.
-->

## Related tickets and documentation

> Please only refer to [evergreen issues](https://github.com/2sugarcubes/astrograph/labels/evergreen)
> in **Related issues** because closes will trigger github to auto-close that issue
> after a successful merge, for more information check out [this article](https://docs.github.com/articles/closing-issues-using-keywords).

<!-- you can have as many or few (including zero) related and closing issues as you need -->

- Related PR #21

## Added/updated tests

> We encourage you to keep code coverage above 50%

<!-- if you add an 'x' inside one of the square brackets it will appear checked in the preview tab -->

- [ ] Yes
- [x] No, and this is why: Remove comment
- [ ] I need help writing tests. No problem,
      we look forward to working with you on this.
