### PR TITLE
docs: improve documentating around long match statement

### DIFF
--- a/bin/src/main.rs
+++ b/bin/src/main.rs
@@ -203,8 +203,7 @@ fn simulate(
 
             program_builder.root_body(root).build().unwrap()
         }
-        // HACK: is there an easier way to return errors if one or more of these fields failed
-        // while reading or parsing? like a "?" operator that could work over a vec?
+        // Error parsing universe
         (Some(Err(e)), Some(Ok(_))) => {
             error!(
                 "Error with universe at {}",
@@ -212,6 +211,7 @@ fn simulate(
             );
             return Err(e);
         }
+        // Error parsing observatories
         (Some(Ok(_)), Some(Err(e))) => {
             error!(
                 "Error with observatories at {}",
@@ -219,6 +219,7 @@ fn simulate(
             );
             return Err(e);
         }
+        // Errors parsing universe and observatories
         (Some(Err(universe_error)), Some(Err(observatoies_error))) => {
             error!(
                 "Errors with universe at {} and observatories at {}",
@@ -230,6 +231,7 @@ fn simulate(
                 observatoies_error,
             ]));
         }
+        // If either observatories or universe was not provided
         (_, None) | (None, _) => {
             let mut program = program_contents?;
             trace!("Reading from program file");


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - 📖 Read the Contributing Guide: https://github.com/2sugarcubes/astrograph/blob/dev/.github/CONTRIBUTING.md#i-want-to-contribute
    - 📖 Read the Code of Conduct: https://github.com/2sugarcubes/astrograph/blob/dev/CODE_OF_CONDUCT.md
    - 👷‍♀️ Create small PRs. The majority of PRs should only need to modify one or two files.
    - ✅ Provide tests for your changes.
    - 📝 Use descriptive commit messages.
    - 📗 Update any related documentation and include any relevant screenshots.

-->

## Description

Adds documentation to give better information around all the match arms.

<!--
TODO: e.g. This changes the log statement in `FILE.rs` to be more human
  readable.
If it doesn't resolve an issue please also provide a description as to
  why it is beneficial to most users or developers.
  e.g. This PR increases test coverage, catching potential future regressions.
-->

## Related tickets and documentation

> Please only refer to [evergreen issues](https://github.com/2sugarcubes/astrograph/labels/evergreen)
> in **Related issues** because closes will trigger github to auto-close that issue
> after a successful merge, for more information check out [this article](https://docs.github.com/articles/closing-issues-using-keywords).

<!-- you can have as many or few (including zero) related and closing issues as you need -->

- Related issue #117

## Added/updated tests

> We encourage you to keep code coverage above 50%

<!-- if you add an 'x' inside one of the square brackets it will appear checked in the preview tab -->

- [ ] Yes
- [x] No, and this is why: Documentation change
- [ ] I need help writing tests. No problem,
      we look forward to working with you on this.