### PR TITLE
fix: remove debug prints of paths

### DIFF
--- a/bin/build.rs
+++ b/bin/build.rs
@@ -21,7 +21,10 @@ fn main() -> std::io::Result<()> {
     // Generate completions
     for &shell in clap_complete::Shell::value_variants() {
         let path = clap_complete::generate_to(shell, &mut cmd, "astrograph", &out_dir)?;
-        println!("cargo::warning=Completion file for {shell: <10} has been generated at: {path:?}");
+        println!(
+            "cargo::warning=Completion file for {shell: <10} has been generated at: {}",
+            path.display()
+        );
     }
 
     Ok(())

--- a/lib/src/program.rs
+++ b/lib/src/program.rs
@@ -213,15 +213,15 @@ mod tests {
         program.add_output(Box::new(Svg::new(projection::StatelessOrthographic())));
 
         // Set output path to an invalid path on windows AND linux
-        let mut path = PathBuf::new();
+        let mut path = String::new();
         if cfg!(windows) {
-            path.push("I:\\\\//");
+            path.push_str("I:\\\\//");
         } else {
-            path.push("/test\0");
+            path.push_str("/test/");
         }
 
-        path.push("\0");
-        path.push(">.<");
+        path.push('\0');
+        path.push_str(">.<");
 
         println!("{path:?}");
         program.set_output_path(path);


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - 📖 Read the Contributing Guide: https://github.com/2sugarcubes/astrograph/blob/dev/.github/CONTRIBUTING.md#i-want-to-contribute
    - 📖 Read the Code of Conduct: https://github.com/2sugarcubes/astrograph/blob/dev/CODE_OF_CONDUCT.md
    - 👷‍♀️ Create small PRs. The majority of PRs should only need to modify one or two files.
    - ✅ Provide tests for your changes.
    - 📝 Use descriptive commit messages.
    - 📗 Update any related documentation and include any relevant screenshots.

-->

## Description

<!--
TODO: e.g. This changes the log statement in `FILE.rs` to be more human
  readable.
If it doesn't resolve an issue please also provide a description as to
  why it is beneficial to most users or developers.
  e.g. This PR increases test coverage, catching potential future regressions.
-->
This removes debug prints of `PathBuf` variables to satiate the clippy lint [unnecessary debug formatting](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_debug_formatting) introduced in rust `1.87.0`.

## Related tickets and documentation

> Please only refer to [evergreen issues](https://github.com/2sugarcubes/astrograph/labels/evergreen)
> in **Related issues** because closes will trigger github to auto-close that issue
> after a successful merge, for more information check out [this article](https://docs.github.com/articles/closing-issues-using-keywords).

<!-- you can have as many or few (including zero) related and closing issues as you need -->

## Added/updated tests

> We encourage you to keep code coverage above 50%

<!-- if you add an 'x' inside one of the square brackets it will appear checked in the preview tab -->

- [ ] Yes
- [x] No, and this is why: update to tests
- [ ] I need help writing tests. No problem,
      we look forward to working with you on this.

## \[optional\] Screenshots or screen-recordings of your change(s) (if it impacts a display)

## \[optional\] What gif or meme best describes this PR or how it makes you feel?

![this meme is from the future, you don't understand it yet](https://cdn.verbub.com/images/this-meme-is-from-the-future-you-don-t-get-it-yet-308795.jpg)